### PR TITLE
fix: Export Iterable extensions

### DIFF
--- a/lib/dfunc.dart
+++ b/lib/dfunc.dart
@@ -20,6 +20,7 @@ export 'src/identity.dart';
 export 'src/ignore.dart';
 export 'src/intersperse.dart';
 export 'src/is_empty.dart';
+export 'src/iterable/extensions.dart';
 export 'src/limit.dart';
 export 'src/map.dart';
 export 'src/map_by.dart';


### PR DESCRIPTION
`iterable/extensions.dart` was included, but wasn't accessible. I've added it to the export.